### PR TITLE
Allow usage as a Node or CommonJS module

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -1,4 +1,19 @@
-chai.use(function (chai) {
+(function (chai_jquery) {
+  // Module systems magic dance.
+  if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
+    // NodeJS
+    module.exports = chai_jquery;
+  } else if (typeof define === "function" && define.amd) {
+    // AMD
+    define(function () {
+      return chai_jquery;
+    });
+  } else {
+    // Other environment (usually <script> tag): pass into global chai
+    var global = (false || eval)("this");
+    global.chai.use(chai_jquery);
+  }
+}(function chai_jquery(chai) {
   var inspect = chai.inspect;
 
   jQuery.fn.inspect = function (depth) {
@@ -169,4 +184,5 @@ chai.use(function (chai) {
       return contain;
     }
   });
-});
+}));
+


### PR DESCRIPTION
I've been playing with chai-jquery and its been great.  However, I also do my testing on the server side (with Node.js) which is currently not supported

Another chai plugin, [sinon-chai](https://github.com/domenic/sinon-chai), allows this, so I took the module loading boiler plate and applied it to chai-jquery.

The one caveat of this approach is that we must explicitly call:

``` javascript
chai.use(chai_jquery);
```

after it has been included with a `<script>` tag.

From the looks of your repos on github, I wouldn't guess you are a Node developer, so you may not be interested in adding support (however CommonJS/AMD is not Node specific and users of RequireJS would benefit from it).

Let me know what you think.  Thanks again from the great plugin!
