### PR TITLE
Support length() assertion on non-jQuery objects. Closes #13

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -192,10 +192,9 @@
 
   chai.Assertion.overwriteProperty('have', function (_super) {
     return function () {
-      _super.call(this);
-      var have = function (selector) {
-        var obj = flag(this, 'object');
-        if (obj instanceof jQuery) {
+      var obj = flag(this, 'object');
+      if (obj instanceof jQuery) {
+        var have = function (selector) {
           this.assert(
               // Using find() rather than has() to work around a jQuery bug:
               //   http://bugs.jquery.com/ticket/11706
@@ -204,10 +203,12 @@
             , 'expected #{this} not to have #{exp}'
             , selector
           );
-        }
-      };
-      have.__proto__ = this;
-      return have;
+        };
+        have.__proto__ = this;
+        return have;
+      } else {
+        _super.call(this);
+      }
     }
   });
 }));

--- a/test/chai-jquery-spec.js
+++ b/test/chai-jquery-spec.js
@@ -553,6 +553,10 @@ describe("jQuery assertions", function(){
     it("preserves existing behavior on non-jQuery objects", function(){
       ({foo: 1, bar: 2}).should.have.property('foo');
     });
+    
+    it("preserves length assertion on non-jQuery objects", function(){
+      (['foo','bar']).should.have.length(2);
+    });
 
     var subject = $('<div><span></span></div>');
 


### PR DESCRIPTION
The have property override always returns a function, and functions have a length property which hides the Chai length() assertion.

This change only returns a have() assertion function if the context is a jQuery object, otherwise it calls _super without returning anything, which allows access to the standard length() assertion from Chai.

Fixes https://github.com/chaijs/chai-jquery/issues/13 
