### PR TITLE
Support inspect with 0 depth

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -18,7 +18,7 @@
 
   jQuery.fn.inspect = function (depth) {
     var el = jQuery('<div />').append(this.clone());
-    if (depth) {
+    if (depth !== undefined) {
       var children = el.children();
       while (depth-- > 0)
         children = children.children();


### PR DESCRIPTION
I usually want to inspect with depth 0 when I'm asserting
things on elements. Sadly, JavaScript is loosly typed so 0
is considered falsy.
