### PR TITLE
`contain` is chainable

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -225,7 +225,7 @@
             , text
           );
         } else {
-          Function.prototype.apply.call(_super.call(this), this, arguments);
+          return Function.prototype.apply.call(_super.call(this), this, arguments);
         }
       };
       setPrototypeOf(contain, this);

--- a/test/chai-jquery-spec.js
+++ b/test/chai-jquery-spec.js
@@ -726,7 +726,11 @@ describe("jQuery assertions", function(){
 
       (function(){
         "foo".should.contain('bar');
-      }).should.fail("expected 'foo' to include 'bar'")
+      }).should.fail("expected 'foo' to include 'bar'");
+
+      (function(){
+        "foo".should.not.contain('bar').and.not.contain('foo');
+      }).should.fail("expected 'foo' to not include 'foo'");
     });
 
     var subject = $('<div><span>example text</span></div>');


### PR DESCRIPTION
In the fallback case, `contain` should ferry along the property return value.
