### PR TITLE
Report actual values in html, text & value assertions

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -135,11 +135,13 @@
   });
 
   chai.Assertion.addMethod('value', function (value) {
+    var actual = flag(this, 'object').val();
     this.assert(
         flag(this, 'object').val() === value
-      , 'expected #{this} to have value #{exp}'
+      , 'expected #{this} to have value #{exp}, but the value was #{act}'
       , 'expected #{this} not to have value #{exp}'
       , value
+      , actual
     );
   });
 

--- a/test/chai-jquery-spec.js
+++ b/test/chai-jquery-spec.js
@@ -424,7 +424,7 @@ describe("jQuery assertions", function(){
     it("fails when the value doesn't match", function(){
       (function(){
         subject.should.have.value("bar");
-      }).should.fail("expected " + inspect(subject) + " to have value 'bar'");
+      }).should.fail("expected " + inspect(subject) + " to have value 'bar', but the value was 'foo'");
     });
 
     it("fails negated when the value matches", function(){


### PR DESCRIPTION
It's helpful to see the actual text value of an element when there's a failure. Same for html & value, so I added them.. unit tests are adjusted accordingly.
