### PR TITLE
Adding a 'focused' assertion property

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Assert that at least one element of the selection is disabled, using [`.is(':dis
     $('.disabled').should.be.disabled;
     expect($('input')).not.to.be.disabled;
 
+### `focused`
+Assert that the first element of the selection is focused, using 
+`$('.element')[0] === document.activeElement` (instead of `.is(':focused')`
+due to https://github.com/ariya/phantomjs/issues/10427)
+
+    $('.focused').should.be.focused;
+    expect($('input')).not.to.be.focused;
+    
 ### `empty`
 Assert that at least one element of the selection is empty, using [`.is(':empty')`](http://api.jquery.com/empty-selector/).
 If the object asserted against is not a jQuery object, the original implementation will be called.

--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -163,6 +163,14 @@
     });
   });
 
+  chai.Assertion.addProperty('focused', function () {
+    this.assert(
+        // Cannot use flag(this, 'object').is(':focus') due to ariya/phantomjs#10427
+        flag(this, 'object')[0] === document.activeElement
+      , 'expected #{this} to be focused'
+      , 'expected #{this} not to be focused');
+  });
+
   chai.Assertion.overwriteProperty('exist', function (_super) {
     return function () {
       var obj = flag(this, 'object');

--- a/test/chai-jquery-spec.js
+++ b/test/chai-jquery-spec.js
@@ -756,4 +756,38 @@ describe("jQuery assertions", function(){
       }).should.fail("expected " + inspect(subject) + " not to have 'span'");
     });
   });
+
+  describe("focused", function(){
+    var subject = $('<input>');
+
+    beforeEach(function() {
+      subject.appendTo('#mocha');
+    });
+
+    afterEach(function() {
+      subject.remove();
+    });
+
+    it("passes when the element is focused", function(){
+      subject.focus();
+      subject.should.be.focused;
+    });
+
+    it("passes negated when the element is not focused", function(){
+      subject.should.not.be.focused;
+    });
+
+    it("fails when the element is not focused", function(){
+      (function(){
+        subject.should.be.focused;
+      }).should.fail("expected " + inspect(subject) + " to be focused");
+    });
+
+    it("fails negated when element is focused", function(){
+      (function(){
+        subject.focus();
+        subject.should.not.be.focused;
+      }).should.fail("expected " + inspect(subject) + " not to be focused");
+    });
+  });
 });


### PR DESCRIPTION
I initially tried `flag(this, 'object').is(':focus')` but that was not passing the test.  Using `document.activeElement` seemed to fix that.  Used http://api.jquery.com/focus/ as a reference.