### PR TITLE
Denote jquery.js is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ provides a set of jQuery-specific assertions.
 
 ## Usage
 
-Include `chai-jquery.js` in your test file, after `chai.js` (version 1.0.0-rc1 or later):
+Include `chai-jquery.js` in your test file, after `jquery.js` and `chai.js` (version 1.0.0-rc1 or later):
 
     <script src="chai-jquery.js"></script>
 


### PR DESCRIPTION
User should include jquery.js in addition to chai.js before including chai-jquery.js. Otherwise error `Can't find variable: jQuery` is shown.

I understand that a new user can guess the requirement of jQuery. I still propose it to be said out loud because the frustration I experienced. In my case I first installed chai-jquery by `npm install chai-jquery` and inserted `<script src="../node_modules/chai-jquery/chai-jquery.js"></script>` into my testrunner.html. I presumed chai-jquery might ship with jQuery so I tried it first without. I got the error `Can't find variable: jQuery` and that was totally predictable.

Unfortunately things turned messy. I installed and included jQuery, `npm install --save-dev jquery` and `<script src="../node_modules/jquery/dist/jquery.js"></script>`. I placed the script tag above chai-jquery.js. But it didn't work, there was similar errors about missing variables. I was confused. I ended up trying different places for the jquery script tag with very weird results and I had to read the code of chai-jquery about when jquery was needed. After one hour, for real, one hour of trying and searching for answer, it struct me that I had made a stupid mistake during script tag insertion: I was missing an opening script tag of the inline js code block that followed the chai-jquery script tag. There problem did not had anything to do with jquery script tag after all.

The bottom line: a little piece of missing documentation led me to try desperately all the possible but fruitless alternatives whether to include jquery or not and where to place it. With the piece, I would have found the real issue quicker. Therefore I propose this pull request that adds that very little but precious piece of documentation.