### PR TITLE
Issue #63 fix - .css() test won't accept hex values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Optionally, assert a particular value as well. The return value is available for
     expect($('body')).to.have.prop('value').match(/bar/);
 
 ### `css(name[, value])`
-Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/).
+Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/). Note that jQuery returns computed (rgb) values for colors, and evaluating against a hex or string will return a test failure.
 Optionally, assert a particular value as well. The return value is available for chaining.
 
     $('#header').should.have.css('background');
-    expect($('body')).to.have.css('background-color', '#ffffff');
+    expect($('body')).to.have.css('background-color', 'rgb(0, 0, 0)');
     expect($('body')).to.have.css('font-family').match(/sans-serif/);
 
 ### `data(name[, value])`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Optionally, assert a particular value as well. The return value is available for
     expect($('body')).to.have.prop('value').match(/bar/);
 
 ### `css(name[, value])`
-Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/). 
+Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/).
 Optionally, assert the computed value as well. The return value is available for chaining.
 
     $('#header').should.have.css('background');

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Optionally, assert a particular value as well. The return value is available for
     expect($('body')).to.have.prop('value').match(/bar/);
 
 ### `css(name[, value])`
-Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/). Note that jQuery returns computed (rgb) values for colors, and evaluating against a hex or string will return a test failure.
-Optionally, assert a particular value as well. The return value is available for chaining.
+Assert that the first element of the selection has the given CSS property, using [`.css()`](http://api.jquery.com/css/). 
+Optionally, assert the computed value as well. The return value is available for chaining.
 
     $('#header').should.have.css('background');
     expect($('body')).to.have.css('background-color', 'rgb(0, 0, 0)');


### PR DESCRIPTION
The documentation is not clear that jQuery's .css() method returns computed values for colors, namely the rgb() values. Testing against string ("red") or hex values will return a false negative.

This addresses #63 .