### PR TITLE
Make possible to use chai-jquery with zombie.js tests by dropping redundant Jquery dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ provides a set of jQuery-specific assertions.
 
 ## Usage
 
+### On client side
+
 Include `chai-jquery.js` in your test file, after `chai.js` (version 1.0.0-rc1 or later):
 
     <script src="chai-jquery.js"></script>
 
 Use the assertions with chai's `expect` or `should` assertions.
+
+### With node.js
+    
+    var chai = require('chai')
+    var chaiJquery = require('chai-jquery')
+    chai.use(function (ch, util) {
+        chaiJquery(ch, util, {})
+    })
 
 ## Assertions
 

--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -232,6 +232,6 @@
   );
 
   function isJquery(obj) {
-    return obj instanceof $;
+    return obj.jquery;
   }
 }));

--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -168,7 +168,7 @@
   chai.Assertion.overwriteProperty('exist', function (_super) {
     return function () {
       var obj = flag(this, 'object');
-      if (obj instanceof $) {
+      if (isJquery(obj)) {
         this.assert(
             obj.length > 0
           , 'expected ' + inspect(obj.selector) + ' to exist'
@@ -182,7 +182,7 @@
   chai.Assertion.overwriteProperty('empty', function (_super) {
     return function () {
       var obj = flag(this, 'object');
-      if (obj instanceof $) {
+      if (isJquery(obj)) {
         this.assert(
           obj.is(':empty')
           , 'expected #{this} to be empty'
@@ -196,7 +196,7 @@
   chai.Assertion.overwriteMethod('match', function (_super) {
     return function (selector) {
       var obj = flag(this, 'object');
-      if (obj instanceof $) {
+      if (isJquery(obj)) {
         this.assert(
             obj.is(selector)
           , 'expected #{this} to match #{exp}'
@@ -213,7 +213,7 @@
     function (_super) {
       return function (text) {
         var obj = flag(this, 'object');
-        if (obj instanceof $) {
+        if (isJquery(obj)) {
           this.assert(
               obj.is(':contains(\'' + text + '\')')
             , 'expected #{this} to contain #{exp}'
@@ -230,4 +230,8 @@
       };
     }
   );
+
+  function isJquery(obj) {
+    return obj instanceof $;
+  }
 }));

--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -41,16 +41,18 @@
       copyProperties(object, Object.getPrototypeOf(prototype));
     };
 
-  $.fn.inspect = function (depth) {
-    var el = $('<div />').append(this.clone());
-    if (depth !== undefined) {
-      var children = el.children();
-      while (depth-- > 0)
-        children = children.children();
-      children.html('...');
-    }
-    return el.html();
-  };
+  if($ && $.fn) {
+    $.fn.inspect = function(depth) {
+      var el = $('<div />').append(this.clone());
+      if (depth !== undefined) {
+        var children = el.children();
+        while (depth-- > 0)
+          children = children.children();
+        children.html('...');
+      }
+      return el.html();
+    };
+  }
 
   var props = {attr: 'attribute', css: 'CSS property', prop: 'property'};
   for (var prop in props) {

--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -156,7 +156,7 @@
     );
   });
 
-  $.each(['visible', 'hidden', 'selected', 'checked', 'enabled', 'disabled'], function (i, attr) {
+  ['visible', 'hidden', 'selected', 'checked', 'enabled', 'disabled'].forEach(function (attr) {
     chai.Assertion.addProperty(attr, function () {
       this.assert(
           flag(this, 'object').is(':' + attr)


### PR DESCRIPTION
In zombie.js tests jQuery object does not exist until a page under test has been loaded. However chai and chai-jquery are loaded before the tests. Therefore $ can't be passed for chai-jquery. Fortunately it is not needed, since $.each can be replaced with native forEach, $.fn.inspect is not required by chai-jquery and obj instanceof $ can be replaced with obj.jquery.
