### PR TITLE
Add documentation for using chai-jquery with an AMD like require.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Include `chai-jquery.js` in your test file, after `chai.js` (version 1.0.0-rc1 o
 <script src="chai-jquery.js"></script>
 ```
 
+If you are using an AMD like requirejs, you can pull in chai-jquery as a dependency, and it will return an initialization function that can be passed to chai:
+
+```js
+require([
+  'chai-jquery'
+], function(chaiJquery) {
+  chai.use(chaiJquery);
+});
+```
+
 Use the assertions with chai's `expect` or `should` assertions.
 
 ## Assertions

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Include `chai-jquery.js` in your test file, after `chai.js` (version 1.0.0-rc1 o
 <script src="chai-jquery.js"></script>
 ```
 
-If you are using an AMD like requirejs, you can pull in chai-jquery as a dependency, and it will return an initialization function that can be passed to chai:
+If you are using an AMD like requirejs, you can pull in chai-jquery as a dependency and it will return an initialization function that can be passed to chai:
 
 ```js
 require([


### PR DESCRIPTION
It took me a minute to look through the source to see how to do this.