### PR TITLE
Create bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "chai-jquery",
+  "description": "jQuery assertions for the Chai assertion library",
+  "keywords": [ "test", "assertion", "assert", "testing", "jQuery" ],
+  "authors": ["John Firebaugh <john.firebaugh@gmail.com>"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chaijs/chai-jquery"
+  },
+  "main": ["./chai-jquery.js"],
+  "ignore": [".git", ".gitignore", ".travis.yml", "test"],
+  "devDependencies": {
+    "chai": "1",
+    "mocha": "1",
+    "mocha-phantomjs": "3",
+    "jquery": "1.9.1 - 2"
+  }
+}


### PR DESCRIPTION
Created bower.json (with same dependencies as in package.json).
`bower install` works OK with it.

Once this PR is merged, one should register the package on Bower, as described here:
http://bower.io/docs/creating-packages/#register

`bower register chai-jquery git://github.com/chaijs/chai-jquery` should do the trick...

