### PR TITLE
Update for Chai v4.0

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -91,7 +91,8 @@
     var assertion = new chai.Assertion(flag(this, 'object').data());
     if (flag(this, 'negate'))
       assertion = assertion.not;
-    return assertion.property(name, val);
+
+    return arguments.length === 1 ? assertion.property(name) : assertion.property(name, val);
   });
 
   chai.Assertion.addMethod('class', function (className) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": ">= 0.4.0"
   },
   "devDependencies": {
-    "chai": "1",
+    "chai": "4",
     "mocha": "1",
     "mocha-phantomjs": "3",
     "jquery": "2.1.0"

--- a/test/chai-jquery-spec.js
+++ b/test/chai-jquery-spec.js
@@ -102,7 +102,7 @@ describe("jQuery assertions", function(){
       it("fails when the element's data does not have the key", function(){
         (function(){
           subject.should.have.data('bar');
-        }).should.fail("expected { name: 'foo' } to have a property 'bar'");
+        }).should.fail("expected { name: 'foo' } to have property 'bar'");
       });
 
       it("fails negated when the element's data has the key", function(){
@@ -128,19 +128,19 @@ describe("jQuery assertions", function(){
       it("fails when the element's data does not have the key", function(){
         (function(){
           subject.should.have.data('bar', 'foo');
-        }).should.fail("expected { name: 'foo' } to have a property 'bar'");
+        }).should.fail("expected { name: 'foo' } to have property 'bar'");
       });
 
       it("fails when the element's data has the key with a different value", function(){
         (function(){
           subject.should.have.data('name', 'bar');
-        }).should.fail("expected { name: 'foo' } to have a property 'name' of 'bar', but got 'foo'")
+        }).should.fail("expected { name: 'foo' } to have property 'name' of 'bar', but got 'foo'")
       });
 
       it("fails negated when the element's data has the key with the given value", function(){
         (function(){
           subject.should.not.have.data('name', 'foo');
-        }).should.fail("expected { name: 'foo' } to not have a property 'name' of 'foo'")
+        }).should.fail("expected { name: 'foo' } to not have property 'name' of 'foo'")
       });
     });
 


### PR DESCRIPTION
A breaking change in Chai v4.0's `property` assertion causes the `data` assertion to fail whenever only one argument is provided. This PR fixes it.