### PR TITLE
Make jQuery a peer dependency and require it.

### DIFF
--- a/chai-jquery.js
+++ b/chai-jquery.js
@@ -2,7 +2,9 @@
   // Module systems magic dance.
   if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // NodeJS
-    module.exports = chaiJquery;
+    module.exports = function (chai, utils) {
+      return chaiJquery(chai, utils, require('jquery'));
+    };
   } else if (typeof define === "function" && define.amd) {
     // AMD
     define(['jquery'], function ($) {
@@ -19,7 +21,6 @@
 }(function (chai, utils, $) {
   var inspect = utils.inspect,
       flag = utils.flag;
-  $ = $ || jQuery;
 
   var setPrototypeOf = '__proto__' in Object ?
     function (object, prototype) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "mocha": "1",
     "mocha-phantomjs": "3",
     "jquery": "2.1.0"
+  },
+  "peerDependencies": {
+    "jquery": "*"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/chaijs/chai-jquery/issues/40.  In CommonJS environments, jQuery would still need to be a global variable, which made using this library more difficult.  Also, adding it as a "*" peer dependency causes NPM to warn that it needs to be installed, without restricting the user to a particular jQuery version.

I acknowledge that some people still might want to specify their own jQuery object, but I am choosing to treat that as a separate feature request.  This change can be considered a "minor correction" independent of other loading enhancements, since it aligns with the way jQuery is currently loaded in AMD environments.  In reaching that parallel, jQuery will be loaded in each of the supported environments' most common manners, respectively.